### PR TITLE
linuxbrew-standalone.sh fix gcc links

### DIFF
--- a/linuxbrew-standalone.sh
+++ b/linuxbrew-standalone.sh
@@ -7,23 +7,28 @@ cd $HOME
 
 # TODO: The next ln -s line breaks cross compiling with multiarch, need an alternative!
 #       source: http://stackoverflow.com/a/9004026/99379
-sudo ln -s /usr/lib/x86_64-linux-gnu /usr/lib64
+if [! -d "/usr/lib64" ]; then
+  # Control will enter here if $DIRECTORY exists.
+  sudo ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 
+fi
 sudo apt-get update -y
 sudo apt-get update --fix-missing -y
 sudo apt-get install build-essential curl g++ git m4 ruby texinfo libbz2-dev libcurl4-openssl-dev libexpat-dev libncurses-dev zlib1g-dev gawk make patch tcl -y
 
 unset LD_LIBRARY_PATH PKG_CONFIG_PATH HOMEBREW_CC
 PATH=$HOME/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin
-yes | ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/linuxbrew/go/install)"
 
-# hang on here. you will have to press return
-# note that even if brew doctor is a little unhappy we want to keep going
-brew doctor || true
+if [! -d "$HOME/.linuxbrew" ]; then
+  yes | ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/linuxbrew/go/install)"
+  # hang on here. you will have to press return
+  # note that even if brew doctor is a little unhappy we want to keep going
+  brew doctor || true
 
-mkdir $HOME/.linuxbrew/lib
-ln -s lib $HOME/.linuxbrew/lib64
-ln -s $HOME/.linuxbrew/lib $HOME/.linuxbrew/lib64
-ln -s /usr/lib64/libstdc++.so.6 /lib64/libgcc_s.so.1 $HOME/.linuxbrew/lib/
+  mkdir $HOME/.linuxbrew/lib
+  ln -s lib $HOME/.linuxbrew/lib64
+  ln -s $HOME/.linuxbrew/lib $HOME/.linuxbrew/lib64
+  ln -s /usr/lib64/libstdc++.so.6 /lib64/libgcc_s.so.1 $HOME/.linuxbrew/lib/
+fi
 PATH=$HOME/.linuxbrew/lib:$PATH
 export PATH
 LIBRARY_PATH=$HOME/.linuxbrew/lib
@@ -38,7 +43,7 @@ export LD_LIBRARY_PATH
 brew install glibc
 brew unlink glibc
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-dupes/master/zlib.rb
-brew reinstall binutils
+brew install binutils
 brew link glibc
 brew install patchelf
 brew install gcc --with-glibc --only-dependencies -v
@@ -46,7 +51,8 @@ brew install gcc --with-glibc --only-dependencies -v
 # TODO: make it so force accepting isn't necessary and errors are shown correctly
 brew install gcc --with-glibc -v || true
 rm -f $HOME/.linuxbrew/lib/{libstdc++.so.6,libgcc_s.so.1}
-brew link gcc --overwrite
+#brew link gcc --overwrite
+brew unlink gcc && brew link gcc
 export HOMEBREW_CC=gcc
 
 brew install bzip2 curl expat


### PR DESCRIPTION
The previous version did not un-link and re-link correctly.
